### PR TITLE
Added extra proof documents to matching data

### DIFF
--- a/data/matchingData/returnCircular.json
+++ b/data/matchingData/returnCircular.json
@@ -189,5 +189,5 @@
   "ageRangeMin": "12",
   "ageRangeMax": "25",
   "proof": "Yes",
-  "proofDocuments": ["studentCard"]
+  "proofDocuments": ["studentCard", "identityDocument", "membershipCard"]
 }


### PR DESCRIPTION
This PR adds a couple of extra proof documents to the returnCircular.json matching data.