### PR TITLE
fix: NeTEX generator to validate when user selects multiple services with same line name/number.

### DIFF
--- a/data/matchingData/flatFare.json
+++ b/data/matchingData/flatFare.json
@@ -13,71 +13,85 @@
   "selectedServices": [
     {
       "lineName": "2C",
+      "serviceCode": "NW_05_BLAC_2C_1",
       "startDate": "05/04/2020",
       "serviceDescription": "KNOTT END - POULTON - BLACKPOOL"
     },
     {
       "lineName": "17",
+      "serviceCode": "NW_05_BLAC_17_1",
       "startDate": "05/04/2020",
       "serviceDescription": "BLACKPOOL - ST ANNES - LYTHAM"
     },
     {
       "lineName": "4",
+      "serviceCode": "NW_05_BLAC_4_1",
       "startDate": "05/04/2020",
       "serviceDescription": "CLEVELEYS - MERESIDE via Blackpool"
     },
     {
       "lineName": "19",
+      "serviceCode": "NW_05_BLAC_19_1",
       "startDate": "05/04/2020",
       "serviceDescription": "STAINING - BLACKPOOL via Victoria Hospital (Main Entrance)"
     },
     {
       "lineName": "1",
+      "serviceCode": "NW_05_BLAC_1_1",
       "startDate": "05/04/2020",
       "serviceDescription": "FLEETWOOD - BLACKPOOL via Promenade"
     },
     {
       "lineName": "2",
+      "serviceCode": "NW_05_BLAC_2_1",
       "startDate": "05/04/2020",
       "serviceDescription": "POULTON - BLACKPOOL via Victoria Hospital Outpatients"
     },
     {
       "lineName": "5",
+      "serviceCode": "NW_05_BLAC_5_1",
       "startDate": "05/04/2020",
       "serviceDescription": "VICTORIA HOSPITAL - BLACKPOOL TOWN CENTRE - HALFWAY HOUSE"
     },
     {
       "lineName": "9",
+      "serviceCode": "NW_05_BLAC_9_1",
       "startDate": "05/04/2020",
       "serviceDescription": "CLEVELEYS - BLACKPOOL via Bispham"
     },
     {
       "lineName": "14",
+      "serviceCode": "NW_05_BLAC_14_1",
       "startDate": "05/04/2020",
       "serviceDescription": "FLEETWOOD - BLACKPOOL via Layton"
     },
     {
       "lineName": "18",
+      "serviceCode": "NW_05_BLAC_18_1",
       "startDate": "05/04/2020",
       "serviceDescription": "BLACKPOOL - MERESIDE via South Shore"
     },
     {
       "lineName": "11",
+      "serviceCode": "NW_05_BLAC_11_1",
       "startDate": "05/04/2020",
       "serviceDescription": "LYTHAM - BLACKPOOL via St Annes"
     },
     {
       "lineName": "3",
+      "serviceCode": "NW_05_BLAC_3_1",
       "startDate": "05/04/2020",
       "serviceDescription": "MERESIDE - BLACKPOOL - CLEVELEYS - CLEVELEYS PARK"
     },
     {
       "lineName": "7",
+      "serviceCode": "NW_05_BLAC_7_1",
       "startDate": "05/04/2020",
       "serviceDescription": "CLEVELEYS - BLACKPOOL - ST ANNES CLIFTON HOSPITAL"
     },
     {
       "lineName": "6",
+      "serviceCode": "NW_05_BLAC_6_1",
       "startDate": "05/04/2020",
       "serviceDescription": "MERESIDE - BLACKPOOL - GRANGE PARK"
     }

--- a/data/matchingData/flatFare.json
+++ b/data/matchingData/flatFare.json
@@ -61,14 +61,14 @@
     },
     {
       "lineName": "14",
-      "serviceCode": "NW_05_BLAC_14_1",
-      "startDate": "05/04/2020",
+      "serviceCode": "NW_07_BLAC_14_1",
+      "startDate": "06/04/2020",
       "serviceDescription": "FLEETWOOD - BLACKPOOL via Layton"
     },
     {
-      "lineName": "18",
-      "serviceCode": "NW_05_BLAC_18_1",
-      "startDate": "05/04/2020",
+      "lineName": "14",
+      "serviceCode": "NW_07_BLAC_14_2",
+      "startDate": "13/04/2020",
       "serviceDescription": "BLACKPOOL - MERESIDE via South Shore"
     },
     {

--- a/data/matchingData/periodMultiService.json
+++ b/data/matchingData/periodMultiService.json
@@ -32,15 +32,15 @@
   "proofDocuments": ["identityDocument"],
   "selectedServices": [
     {
-      "lineName": "2C",
-      "serviceCode": "NW_05_BLAC_2C_1",
-      "startDate": "05/04/2020",
+      "lineName": "25",
+      "serviceCode": "NW_07_BLAC_25_1",
+      "startDate": "06/04/2020",
       "serviceDescription": "KNOTT END - POULTON - BLACKPOOL"
     },
     {
-      "lineName": "17",
-      "serviceCode": "NW_05_BLAC_17_1",
-      "startDate": "05/04/2020",
+      "lineName": "25",
+      "serviceCode": "NW_07_BLAC_25_2",
+      "startDate": "13/04/2020",
       "serviceDescription": "BLACKPOOL - ST ANNES - LYTHAM"
     },
     {

--- a/data/matchingData/periodMultiService.json
+++ b/data/matchingData/periodMultiService.json
@@ -33,71 +33,85 @@
   "selectedServices": [
     {
       "lineName": "2C",
+      "serviceCode": "NW_05_BLAC_2C_1",
       "startDate": "05/04/2020",
       "serviceDescription": "KNOTT END - POULTON - BLACKPOOL"
     },
     {
       "lineName": "17",
+      "serviceCode": "NW_05_BLAC_17_1",
       "startDate": "05/04/2020",
       "serviceDescription": "BLACKPOOL - ST ANNES - LYTHAM"
     },
     {
       "lineName": "4",
+      "serviceCode": "NW_05_BLAC_4_1",
       "startDate": "05/04/2020",
       "serviceDescription": "CLEVELEYS - MERESIDE via Blackpool"
     },
     {
       "lineName": "19",
+      "serviceCode": "NW_05_BLAC_19_1",
       "startDate": "05/04/2020",
       "serviceDescription": "STAINING - BLACKPOOL via Victoria Hospital (Main Entrance)"
     },
     {
       "lineName": "1",
+      "serviceCode": "NW_05_BLAC_1_1",
       "startDate": "05/04/2020",
       "serviceDescription": "FLEETWOOD - BLACKPOOL via Promenade"
     },
     {
       "lineName": "2",
+      "serviceCode": "NW_05_BLAC_2_1",
       "startDate": "05/04/2020",
       "serviceDescription": "POULTON - BLACKPOOL via Victoria Hospital Outpatients"
     },
     {
       "lineName": "5",
+      "serviceCode": "NW_05_BLAC_5_1",
       "startDate": "05/04/2020",
       "serviceDescription": "VICTORIA HOSPITAL - BLACKPOOL TOWN CENTRE - HALFWAY HOUSE"
     },
     {
       "lineName": "9",
+      "serviceCode": "NW_05_BLAC_9_1",
       "startDate": "05/04/2020",
       "serviceDescription": "CLEVELEYS - BLACKPOOL via Bispham"
     },
     {
       "lineName": "14",
+      "serviceCode": "NW_05_BLAC_14_1",
       "startDate": "05/04/2020",
       "serviceDescription": "FLEETWOOD - BLACKPOOL via Layton"
     },
     {
       "lineName": "18",
+      "serviceCode": "NW_05_BLAC_18_1",
       "startDate": "05/04/2020",
       "serviceDescription": "BLACKPOOL - MERESIDE via South Shore"
     },
     {
       "lineName": "11",
+      "serviceCode": "NW_05_BLAC_11_1",
       "startDate": "05/04/2020",
       "serviceDescription": "LYTHAM - BLACKPOOL via St Annes"
     },
     {
       "lineName": "3",
+      "serviceCode": "NW_05_BLAC_3_1",
       "startDate": "05/04/2020",
       "serviceDescription": "MERESIDE - BLACKPOOL - CLEVELEYS - CLEVELEYS PARK"
     },
     {
       "lineName": "7",
+      "serviceCode": "NW_05_BLAC_7_1",
       "startDate": "05/04/2020",
       "serviceDescription": "CLEVELEYS - BLACKPOOL - ST ANNES CLIFTON HOSPITAL"
     },
     {
       "lineName": "6",
+      "serviceCode": "NW_05_BLAC_6_1",
       "startDate": "05/04/2020",
       "serviceDescription": "MERESIDE - BLACKPOOL - GRANGE PARK"
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,3 @@
+{
+  "lockfileVersion": 1
+}


### PR DESCRIPTION
Changes have been made to flatFare.json and periodMultiService.json si that they include multiple services with the same line name/number.