### PR TITLE
Added create-local-dynamodb-table to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -87,8 +87,8 @@ create-local-buckets:
 	awslocal s3 mb s3://fdbt-unvalidated-netex-data-dev
 
 create-local-dynamodb-table:
-	awslocal dynamodb create-table --attribute-definitions AttributeName=id,AttributeType=S --table-name local-sessions --key-schema AttributeName=id,KeyType=HASH --billing-mode PAY_PER_REQUEST
-	awslocal dynamodb update-time-to-live --table-name local-sessions --time-to-live-specification "Enabled=true, AttributeName=ttl"
+	awslocal dynamodb create-table --attribute-definitions AttributeName=id,AttributeType=S --table-name sessions --key-schema AttributeName=id,KeyType=HASH --billing-mode PAY_PER_REQUEST
+	awslocal dynamodb update-time-to-live --table-name sessions --time-to-live-specification "Enabled=true, AttributeName=ttl"
 
 create-sns-topics:
 	awslocal sns create-topic --name AlertsTopic

--- a/Makefile
+++ b/Makefile
@@ -88,6 +88,7 @@ create-local-buckets:
 
 create-local-dynamodb-table:
 	awslocal dynamodb create-table --attribute-definitions AttributeName=id,AttributeType=S --table-name local-sessions --key-schema AttributeName=id,KeyType=HASH --billing-mode PAY_PER_REQUEST
+	awslocal dynamodb update-time-to-live --table-name local-sessions --time-to-live-specification "Enabled=true, AttributeName=ttl"
 
 create-sns-topics:
 	awslocal sns create-topic --name AlertsTopic

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 PROJECT_NAME=fdbt
 UNVALIDATED_NETEX_BUCKET=fdbt-unvalidated-netex-data-dev
 
-dev: docker-up wait-for-mysql data-reset wait-for-s3-and-sns create-local-buckets create-sns-topics add-data-to-buckets print-help start-site
+dev: docker-up wait-for-mysql data-reset wait-for-s3-and-sns create-local-buckets create-local-dynamodb-table create-sns-topics add-data-to-buckets print-help start-site
 
 
 # DOCKER
@@ -85,6 +85,9 @@ create-local-buckets:
 	awslocal s3 mb s3://fdbt-matching-data-dev
 	awslocal s3 mb s3://fdbt-netex-data-dev
 	awslocal s3 mb s3://fdbt-unvalidated-netex-data-dev
+
+create-local-dynamodb-table:
+	awslocal dynamodb create-table --attribute-definitions AttributeName=id,AttributeType=S --table-name local-sessions --key-schema AttributeName=id,KeyType=HASH --billing-mode PAY_PER_REQUEST
 
 create-sns-topics:
 	awslocal sns create-topic --name AlertsTopic

--- a/Makefile
+++ b/Makefile
@@ -88,7 +88,7 @@ create-local-buckets:
 
 create-local-dynamodb-table:
 	awslocal dynamodb create-table --attribute-definitions AttributeName=id,AttributeType=S --table-name sessions --key-schema AttributeName=id,KeyType=HASH --billing-mode PAY_PER_REQUEST
-	awslocal dynamodb update-time-to-live --table-name sessions --time-to-live-specification "Enabled=true, AttributeName=ttl"
+	awslocal dynamodb update-time-to-live --table-name sessions --time-to-live-specification "Enabled=true, AttributeName=expires"
 
 create-sns-topics:
 	awslocal sns create-topic --name AlertsTopic

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,8 +17,9 @@ services:
     tty: true
     stdin_open: true
     environment:
-      SERVICES: s3,s3api,sns
+      SERVICES: s3,s3api,sns,dynamodb
       DATA_DIR: /tmp/localstack/data
     ports:
       - "4572:4572"
       - "4575:4575"
+      - "4569:4569"


### PR DESCRIPTION
# Description

This PR adds an extra step to the Makefile which allows for creation of a local dynamodb table using localstack. For ease, the new command has been added to the default `make` command.

Related PRs:
-   `fdbt-site` repo - https://github.com/fares-data-build-tool/fdbt-site/pull/109
-   `fdbt-aws` repo - https://github.com/fares-data-build-tool/fdbt-aws/pull/14

# Testing

- To test this PR, pull down this branch and run `make` in the `fdbt-dev` repo.
- You can verify that the local dynamodb table has been created by running `awslocal dynamodb describe-table --table-name sessions`.

# Debugging

- If you have issues running the Makefile, try running the `make delete-all` command to remove all docker containers and images running on your machine.