### PR TITLE
refactor: readme updates and remove ts-node global install

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,9 @@ This repo facilitates the development of the Fares Data Build Tool by providing 
 ## Requirements
 
 - [Docker](https://docs.docker.com/install/)
+- [Docker Compose](https://docs.docker.com/compose/install/)
 - [MySQL 5.6](https://dev.mysql.com/doc/mysql-getting-started/en/)
+  - For Ubuntu users, if you cannot install MySQL 5.6 using the [MySQL APT Repository](https://dev.mysql.com/downloads/repo/apt/), follow the instructions [here](https://dev.mysql.com/doc/refman/8.0/en/linux-installation-debian.html)
 - [LocalStack AWS CLI](https://github.com/localstack/awscli-local)
 - [jq](https://stedolan.github.io/jq/download/)
 
@@ -25,12 +27,18 @@ In order to use the scripts in this repo, the FDBT repos need to be in a particu
 
 ## Running the Fares Data Build Tool
 
-Set the env var `FDBT_ROOT` in your .zshrc or .bashrc to be the absolute path to the root of the above structure:
+| Var          | Description                                                            |
+| ------------ | ---------------------------------------------------------------------- |
+| PATH_TO_ROOT | The absolute path to the root of the [repo structure](#repo-structure) |
+| COGNITO_USER_POOL_ID | In the AWS console, using the cfd-test role, Cognito -> Manage User Pools -> fdbt-user-pool-test -> **Pool Id** |
+| COGNITO_USER_POOL_CLIENT_ID | In the AWS console, using the cfd-test role, Cognito -> Manage User Pools -> fdbt-user-pool-test -> App clients -> **App client id** |
+
+Set the above env vars in your .zshrc or .bashrc:
 
 ```bash
 export FDBT_ROOT={PATH_TO_ROOT}
-export FDBT_USER_POOL_ID={COGNITO USER POOL ID}
-export FDBT_USER_POOL_CLIENT_ID={COGNITO USER POOL CLIENT ID}
+export FDBT_USER_POOL_ID={COGNITO_USER_POOL_ID}
+export FDBT_USER_POOL_CLIENT_ID={COGNITO_USER_POOL_CLIENT_ID}
 ```
 
 The site and infrastructure can then be brought up by simply running:

--- a/scripts/trigger_netex_convertor.sh
+++ b/scripts/trigger_netex_convertor.sh
@@ -8,8 +8,8 @@ UNVALIDATED_NETEX_BUCKET=fdbt-unvalidated-netex-data-dev
 
 EVENT_DATA=$(cat $FDBT_ROOT/fdbt-dev/data/s3Events/putEvent.json | sed s:KEY_HERE:BLAC/$FILE_NAME.json:g | sed s:BUCKET_HERE:$BUCKET_NAME:g)
 
-cd $FDBT_ROOT/repos/fdbt-netex-output/src/netex-convertor
+cd $FDBT_ROOT/repos/fdbt-netex-output
 
-rm -rf build
+rm -rf src/netex-convertor/build
 
-NODE_ENV=development UNVALIDATED_NETEX_BUCKET=$UNVALIDATED_NETEX_BUCKET ts-node run-local.ts "$EVENT_DATA"
+EVENT_DATA=$EVENT_DATA UNVALIDATED_NETEX_BUCKET=$UNVALIDATED_NETEX_BUCKET npm run netexConvert

--- a/scripts/trigger_netex_emailer.sh
+++ b/scripts/trigger_netex_emailer.sh
@@ -8,9 +8,9 @@ MATCHING_DATA_BUCKET=fdbt-matching-data-dev
 
 EVENT_DATA=$(cat $FDBT_ROOT/fdbt-dev/data/s3Events/putEvent.json | sed s:KEY_HERE:BLAC/$FILE_NAME.xml:g | sed s:BUCKET_HERE:$NETEX_BUCKET:g)
 
-cd $FDBT_ROOT/repos/fdbt-netex-output/src/netex-emailer/
+cd $FDBT_ROOT/repos/fdbt-netex-output
 
-rm -rf build
+rm -rf src/netex-emailer/build
 
-NODE_ENV=development MATCHING_DATA_BUCKET=$MATCHING_DATA_BUCKET ts-node run-local.ts "$EVENT_DATA"
+EVENT_DATA=$EVENT_DATA MATCHING_DATA_BUCKET=$MATCHING_DATA_BUCKET npm run netexEmail
 


### PR DESCRIPTION
# Description
-   README updated with instructions for Ubuntu users
-   Need for global ts-node install removed
# Testing instructions
-   Ran both scripts that requires ts-node (`trigger_netex_converter.sh` and `trigger_netex_emailer.sh`) before and after the change, confirmed that output was identical
# Type of change
-   [ ] feat - A new feature
-   [ ] fix - A bug fix
-   [ ] docs - Documentation only changes
-   [ ] codestyle - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
-   [x] refactor - A code change that neither fixes a bug nor adds a feature
-   [ ] perf - A code change that improves performance
-   [ ] test - Adding missing tests or correcting existing tests
-   [ ] build - Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
-   [ ] ci - Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
-   [ ] chore - Other changes that don't modify src or test files
-   [ ] revert - Reverts a previous commit
-   [ ] content - Changes to content or copy
# Checklist:
-   [x] Able to run pr locally
-   [x] Followed acceptance criteria
-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my own code
-   [x] I have made corresponding changes to the documentation if applicable